### PR TITLE
add: Selectable processing type to BTree and FSM

### DIFF
--- a/addons/behaviour_toolkit/behaviour_tree/bt_behaviour.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_behaviour.gd
@@ -3,7 +3,7 @@ class_name BTBehaviour extends BehaviourToolkit
 
 
 enum Status {
-    SUCCESS,
-    FAILURE,
-    RUNNING
+	SUCCESS,
+	FAILURE,
+	RUNNING
 }

--- a/addons/behaviour_toolkit/behaviour_tree/bt_leaf.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_leaf.gd
@@ -3,4 +3,4 @@ class_name BTLeaf extends BTBehaviour
 
 
 func tick(_actor: Node, _blackboard: Blackboard) -> Status:
-    return Status.SUCCESS
+	return Status.SUCCESS

--- a/addons/behaviour_toolkit/behaviour_tree/bt_root.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_root.gd
@@ -1,28 +1,58 @@
 @icon("res://addons/behaviour_toolkit/icons/BTRoot.svg")
 class_name BTRoot extends BehaviourToolkit
+## Node used as a base parent (root) of a Behaviour Tree
+
+
+enum ProcessType {
+	IDLE, ## Updates on every rendered frame (at current FPS).
+	PHYSICS ## Updates on a fixed rate (60 FPS by default) synchornized with physics thread. 
+}
 
 
 @export var autostart: bool = false
-var active: bool = false
+
+## Can be used to select if Behaviour Tree tick() is calculated on
+## rendering (IDLE) frame or physics (PHYSICS) frame. 
+## [br]
+## More info: [method Node._process] and [method Node._physics_process]
+@export var process_type: ProcessType = ProcessType.PHYSICS:
+	set(value):
+		process_type = value
+		_setup_processing()
+
 @export var actor: Node
 @export var blackboard: Blackboard
+
+
+var active: bool = false
+var current_status: BTBehaviour.Status
 
 
 @onready var entry_point = get_child(0)
 
 
-var current_status: BTBehaviour.Status
-
-
-func _ready():
+func _ready() -> void:
 	if blackboard == null:
 		blackboard = _create_local_blackboard()
 
 	if autostart:
 		active = true
 
+	if not process_type:
+		process_type = ProcessType.PHYSICS
 
-func _process(delta):
+	_setup_processing()
+
+
+func  _physics_process(delta: float) -> void:
+	_process_code(delta)
+
+
+func _process(delta: float) -> void:
+	_process_code(delta)
+
+
+func _process_code(delta: float) -> void:
 	if not active:
 		return
 	
@@ -33,3 +63,9 @@ func _process(delta):
 func _create_local_blackboard() -> Blackboard:
 	var blackboard: Blackboard = Blackboard.new()
 	return blackboard
+
+
+# Configures process type to use, if BTree is not active both are disabled.
+func _setup_processing() -> void:
+	set_physics_process(process_type == ProcessType.PHYSICS)
+	set_process(process_type == ProcessType.IDLE)

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
@@ -6,17 +6,17 @@ class_name BTIntegratedFSM extends BTComposite
 
 
 func tick(_actor: Node, _blackboard: Blackboard) -> Status:
-    if state_machine.active == false:
-        state_machine.start()
+	if state_machine.active == false:
+		state_machine.start()
 
-    if not state_machine.current_bt_status == Status.RUNNING:
-        state_machine.active = false
-    
-    return state_machine.current_bt_status
+	if not state_machine.current_bt_status == Status.RUNNING:
+		state_machine.active = false
+	
+	return state_machine.current_bt_status
 
 
 func _get_machine() -> FiniteStateMachine:
-    if get_child_count() == 0:
-        return null
-    else:
-        return get_child(0)
+	if get_child_count() == 0:
+		return null
+	else:
+		return get_child(0)

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
@@ -8,21 +8,21 @@ var transitions: Array[FSMTransition] = []
 
 
 func _ready() -> void:
-    for transition in get_children():
-        if transition is FSMTransition:
-            transitions.append(transition)
+	for transition in get_children():
+		if transition is FSMTransition:
+			transitions.append(transition)
 
 
 ## Executes after the state is entered.
 func _on_enter(_actor: Node, _blackboard: Blackboard) -> void:
-    pass
+	pass
 
 
-## Executes every _process call, if the state is active.
+## Executes every process call, if the state is active.
 func _on_update(_actor: Node, _blackboard: Blackboard) -> void:
-    pass
+	pass
 
 
 ## Executes before the state is exited.
 func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
-    pass
+	pass

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
@@ -13,27 +13,27 @@ class_name FSMStateIntegratedBT extends FSMState
 
 ## Executes after the state is entered.
 func _on_enter(_actor: Node, _blackboard: Blackboard) -> void:
-    behaviour_tree.active = true
+	behaviour_tree.active = true
 
 
-## Executes every _process call, if the state is active.
+## Executes every process call, if the state is active.
 func _on_update(_actor: Node, _blackboard: Blackboard) -> void:
-    if behaviour_tree.current_status == on_status:
-        if fire_event_on_status:
-            get_parent().fire_event(event)
+	if behaviour_tree.current_status == on_status:
+		if fire_event_on_status:
+			get_parent().fire_event(event)
 
 
 ## Executes before the state is exited.
 func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
-    behaviour_tree.active = false
+	behaviour_tree.active = false
 
 
 func _get_behaviour_tree() -> BTRoot:
-    if get_child_count() == 0:
-        return null
-    
-    for child in get_children():
-        if child is BTRoot:
-            return child
+	if get_child_count() == 0:
+		return null
+	
+	for child in get_children():
+		if child is BTRoot:
+			return child
 
-    return null
+	return null

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state_integration_return.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state_integration_return.gd
@@ -2,8 +2,8 @@
 class_name FSMStateIntegrationReturn extends FSMState
 
 enum Status {
-    SUCCESS,
-    FAILURE
+	SUCCESS,
+	FAILURE
 }
 
 @export var return_value: Status = Status.SUCCESS
@@ -11,14 +11,14 @@ enum Status {
 
 ## Executes after the state is entered.
 func _on_enter(_actor: Node, _blackboard: Blackboard) -> void:
-    get_parent().current_bt_status = return_value
+	get_parent().current_bt_status = return_value
 
 
-## Executes every _process call, if the state is active.
+## Executes every process call, if the state is active.
 func _on_update(_actor: Node, _blackboard: Blackboard) -> void:
-    pass
+	pass
 
 
 ## Executes before the state is exited.
 func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
-    pass
+	pass

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -72,6 +72,9 @@ This is the root node of the State Machine. All `FSMStates` must be children of 
 #### Properties
 - bool `autostart`
     - If `true` the FSM will start automatically when ready.
+- Enum `process_type`
+    - When set to `Physics` the FSM _on_update() will be run in `_physics_process()` callback.
+    - When set to `Idle` the FSM _on_update() will be run in `_process()` callback.
 - bool `active`
     - When `true` the State Machine will run and update its current state.
 - FSMState `initial_state`
@@ -142,6 +145,9 @@ This is the root of your behaviour tree. It is designed to only have one child n
 #### Properties
 - bool `autostart`
     - If `true` the FSM will start automatically when ready.
+- Enum `process_type`
+    - When set to `Physics` the BTree tick() will be run in `_physics_process()` callback.
+    - When set to `Idle` the BTree tick() will be run in `_process()` callback.
 - bool `active`
     - When `true` the State Machine will run and update its current state.
 - FSMState `initial_state`

--- a/examples/behaviour_example/NPCs/villager.tscn
+++ b/examples/behaviour_example/NPCs/villager.tscn
@@ -325,6 +325,7 @@ wait_for_ticks = 150
 [node name="AnimationStateMachine" type="Node" parent="." node_paths=PackedStringArray("initial_state", "actor")]
 script = ExtResource("8_5ft4q")
 autostart = true
+process_type = 0
 initial_state = NodePath("Idle")
 actor = NodePath("..")
 blackboard = ExtResource("4_opmou")


### PR DESCRIPTION
User can select if he wants BTree or/and FSM updates to take place in render IDLE frame or PHYSICS thread frame.

For now `active` is evaluated like it used to. I had some weird issues after changing it so I will leave it for another PR.