### PR TITLE
Makes BTComposite nodes aware of changes in their children

### DIFF
--- a/addons/behaviour_toolkit/behaviour_tree/bt_composite.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_composite.gd
@@ -1,6 +1,24 @@
 @icon("res://addons/behaviour_toolkit/icons/BTComposite.svg")
 class_name BTComposite extends BTBehaviour
+## Basic Composite node for Behaviour Tree.
+##
+## By itself is not doing much but is aware of it's children. You can use it
+## to implement custom composite behaviours. If you Implement custom composite
+## node remember to call [code]super()[/code] first in your custom node
+## [code]_ready()[/code] callback!
 
 
 ## The leaves under the composite node.
 @onready var leaves: Array = get_children()
+
+
+func _ready() -> void:
+	connect("child_order_changed", _on_child_order_changed)
+
+
+## BTComposite updates [member BTComposite.leaves] when it's children nodes are
+## added, moved or deleted. If you implement custom composite node remember to
+## call [code]super()[/code] first in your custom node [code]_ready()[/code] 
+## callback!
+func _on_child_order_changed() -> void:
+	leaves = get_children()

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
@@ -5,6 +5,11 @@ class_name BTIntegratedFSM extends BTComposite
 @onready var state_machine: FiniteStateMachine = _get_machine()
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(_actor: Node, _blackboard: Blackboard) -> Status:
 	if state_machine.active == false:
 		state_machine.start()

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random.gd
@@ -12,18 +12,21 @@ var active_leave: BTBehaviour
 
 
 func _ready():
-    if use_seed:
-        rng.seed = hash(seed)
+	# Important to add when extending BTComposite!
+	super()
+	
+	if use_seed:
+		rng.seed = hash(seed)
 
 
 func tick(actor: Node, blackboard: Blackboard):
-    if active_leave == null:
-        active_leave = leaves[rng.randi() % leaves.size()]
-    
-    var response = active_leave.tick(actor, blackboard)
-    
-    if response == Status.RUNNING:
-        return response
-    
-    active_leave = null
-    return response
+	if active_leave == null:
+		active_leave = leaves[rng.randi() % leaves.size()]
+	
+	var response = active_leave.tick(actor, blackboard)
+	
+	if response == Status.RUNNING:
+		return response
+	
+	active_leave = null
+	return response

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_selector.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_selector.gd
@@ -7,6 +7,11 @@ var is_shuffled: bool = false
 var current_leaf: int = 0
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(actor: Node, blackboard: Blackboard):
 	if not is_shuffled:
 		leaves.shuffle()

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_sequence.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_sequence.gd
@@ -7,6 +7,11 @@ var is_shuffled: bool = false
 var current_leaf: int = 0
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(actor: Node, blackboard: Blackboard):
 	if not is_shuffled:
 		leaves.shuffle()

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_selector.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_selector.gd
@@ -6,6 +6,11 @@ class_name BTSelector extends BTComposite
 var current_leaf: int = 0
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(actor: Node, blackboard: Blackboard):
 	if current_leaf > leaves.size() -1:
 		current_leaf = 0

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_sequence.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_sequence.gd
@@ -6,6 +6,11 @@ class_name BTSequence extends BTComposite
 var current_leaf: int = 0
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(actor: Node, blackboard: Blackboard):
 	if current_leaf > leaves.size() -1:
 		current_leaf = 0

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_simple_parallel.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_simple_parallel.gd
@@ -18,6 +18,11 @@ enum ParallelPolicy {
 @onready var responses: Dictionary = {}
 
 
+func _ready() -> void:
+	# Important to add when extending BTComposite!
+	super()
+
+
 func tick(actor: Node, blackboard: Blackboard):
 	var leave_counter = 0
 	for leave in leaves:


### PR DESCRIPTION
This makes possible to change children of a composite nodes at runtime, allowing for many cool stuff. 😄

I use it for injecting custom behaviors in a skill system in my game.

For AI it could be used to build mob generator, that takes scenes with pre-defined elements and creates many possible combinations, without need to create each scene manually by instancing sub-scenes.