### PR TITLE
Removed class_name of an example scene

### DIFF
--- a/examples/behaviour_example/actor/actor.gd
+++ b/examples/behaviour_example/actor/actor.gd
@@ -1,4 +1,4 @@
-class_name Actor extends CharacterBody2D
+extends CharacterBody2D
 
 
 @export var age: int = 1


### PR DESCRIPTION
Actor class_name is not needed, gives impression that actors in BT need to be the Actor class, which is not the case and might conflict with user's own Actor class if they add examples to their main project.