### PR TITLE
fix: Static Typing for _get_configuration_warnings

### DIFF
--- a/addons/behaviour_toolkit/behaviour_tree/bt_leaf.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_leaf.gd
@@ -2,7 +2,7 @@
 @icon("res://addons/behaviour_toolkit/icons/BTLeaf.svg")
 class_name BTLeaf extends BTBehaviour
 ## A leaf is where the actual logic that controlls the actor or other nodes
-## is implemented. 
+## is implemented.
 ##
 ## It is the base class for all leaves and can be extended to implement
 ## custom behaviours.[br]
@@ -16,13 +16,13 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 
 func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
-	
+
 	var parent = get_parent()
 	var children = get_children()
 
 	if not parent is BTBehaviour and not parent is BTRoot:
 		warnings.append("BTLeaf node must be a child of BTBehaviour or BTRoot node.")
-	
+
 	if children.size() > 0:
 		warnings.append("BTLeaf node must not have any children.")
 

--- a/addons/behaviour_toolkit/behaviour_tree/bt_leaf_integration.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_leaf_integration.gd
@@ -10,7 +10,7 @@ class_name BTLeafIntegration extends BTLeaf
 		update_configuration_warnings()
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_integrated_fsm.gd
@@ -40,7 +40,7 @@ func _get_machine() -> FiniteStateMachine:
 		return get_child(0)
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 	var children = get_children()
 

--- a/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_call.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_call.gd
@@ -56,7 +56,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 	return BTStatus.SUCCESS
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_condition.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_condition.gd
@@ -139,7 +139,7 @@ func tick(delta: float, actor: Node, _blackboard: Blackboard):
 		return BTStatus.SUCCESS
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_event.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_event.gd
@@ -15,7 +15,7 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 	return return_status
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_signal.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_signal.gd
@@ -68,7 +68,7 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 	return BTStatus.SUCCESS
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_tween.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/leaves/leaf_tween.gd
@@ -131,7 +131,7 @@ func _init_tween(actor: Node, blackboard: Blackboard):
 			tween.tween_property(actor, tween_property, tween_value, duration)
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
@@ -10,6 +10,7 @@ class_name FSMState extends BehaviourToolkit
 ## To implement your logic you can override the [code]_on_enter, _on_update and
 ## _on_exit[/code] methods when extending the node's script.
 
+
 ## List of transitions from this state.
 var transitions: Array[FSMTransition] = []
 

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state.gd
@@ -10,7 +10,6 @@ class_name FSMState extends BehaviourToolkit
 ## To implement your logic you can override the [code]_on_enter, _on_update and
 ## _on_exit[/code] methods when extending the node's script.
 
-
 ## List of transitions from this state.
 var transitions: Array[FSMTransition] = []
 
@@ -40,8 +39,8 @@ func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
 	pass
 
 
-func _get_configuration_warnings():
-	var warnings = []
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: Array = []
 
 	var parent: Node = get_parent()
 	if not parent is FiniteStateMachine:

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
@@ -14,7 +14,9 @@ class_name FSMStateIntegratedBT extends FSMState
 ## Behaviour Tree. You can also use the [FSMEvent] leaf to trigger custom
 ## events inside the nested State Machine.
 
+
 @onready var behaviour_tree: BTRoot = _get_behaviour_tree()
+
 
 @export var fire_event_on_status: bool = false:
 	set(value):

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state_integrated_bt.gd
@@ -14,9 +14,7 @@ class_name FSMStateIntegratedBT extends FSMState
 ## Behaviour Tree. You can also use the [FSMEvent] leaf to trigger custom
 ## events inside the nested State Machine.
 
-
 @onready var behaviour_tree: BTRoot = _get_behaviour_tree()
-
 
 @export var fire_event_on_status: bool = false:
 	set(value):
@@ -53,14 +51,15 @@ func _get_behaviour_tree() -> BTRoot:
 
 	if get_child_count() == 0:
 		return null
-	
+
 	for child in get_children():
 		if child is BTRoot:
 			return child
 
 	return null
 
-func _get_configuration_warnings():
+
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())
@@ -73,11 +72,13 @@ func _get_configuration_warnings():
 			has_root = true
 		elif not child is FSMTransition:
 			warnings.append("FSMStateIntegratedBT can only have BTRoot and FSMTransition children.")
-	
+
 	if not has_root:
 		warnings.append("FSMStateIntegratedBT must have a BTRoot child node.")
-	
+
 	if fire_event_on_status and event == "":
-		warnings.append("FSMStateIntegratedBT has fire_event_on_status enabled, but no event is set.")
+		warnings.append(
+			"FSMStateIntegratedBT has fire_event_on_status enabled, but no event is set."
+		)
 
 	return warnings

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_state_integration_return.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_state_integration_return.gd
@@ -7,7 +7,6 @@ class_name FSMStateIntegrationReturn extends FSMState
 ## [enum BTStatus.FAILURE] depending on the state's return_status property,
 ## which stops execution of FSM attached to [BTIntegratedFSM].
 
-
 enum BTStatus {
 	SUCCESS,
 	FAILURE,
@@ -31,7 +30,7 @@ func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
 	pass
 
 
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_transition.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_transition.gd
@@ -11,7 +11,6 @@ class_name FSMTransition extends BehaviourToolkit
 ## [code]use_event[/code] to true and set the event property to the name
 ## of the event you want to listen for.
 
-
 ## The state to transition to.
 @export var next_state: FSMState:
 	set(value):
@@ -44,7 +43,7 @@ func is_valid(_actor: Node, _blackboard: Blackboard) -> bool:
 func is_valid_event(current_event: String) -> bool:
 	if current_event == "":
 		return false
-	
+
 	return current_event == event
 
 
@@ -53,16 +52,16 @@ func get_next_state() -> FSMState:
 	return next_state
 
 
-func _get_configuration_warnings():
-	var warnings = []
+func _get_configuration_warnings() -> PackedStringArray:
+	var warnings: Array = []
 
 	var parent: Node = get_parent()
 	if not parent is FSMState:
 		warnings.append("FSMTransition should be a child of FSMState.")
-	
+
 	if not next_state:
 		warnings.append("FSMTransition has no next state.")
-	
+
 	if use_event and event == "":
 		warnings.append("FSMTransition has no event set.")
 

--- a/addons/behaviour_toolkit/finite_state_machine/fsm_transition.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm_transition.gd
@@ -11,6 +11,7 @@ class_name FSMTransition extends BehaviourToolkit
 ## [code]use_event[/code] to true and set the event property to the name
 ## of the event you want to listen for.
 
+
 ## The state to transition to.
 @export var next_state: FSMState:
 	set(value):

--- a/script_templates/BTComposite/new_composite.gd
+++ b/script_templates/BTComposite/new_composite.gd
@@ -13,7 +13,7 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 
 # Add custom configuration warnings
 # Note: Can be deleted if you don't want to define your own warnings.
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/script_templates/BTDecorator/new_decorator.gd
+++ b/script_templates/BTDecorator/new_decorator.gd
@@ -14,7 +14,7 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 
 # Add custom configuration warnings
 # Note: Can be deleted if you don't want to define your own warnings.
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/script_templates/BTLeaf/new_leaf.gd
+++ b/script_templates/BTLeaf/new_leaf.gd
@@ -11,7 +11,7 @@ func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
 
 # Add custom configuration warnings
 # Note: Can be deleted if you don't want to define your own warnings.
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/script_templates/FSMState/new_state.gd
+++ b/script_templates/FSMState/new_state.gd
@@ -19,7 +19,7 @@ func _on_exit(_actor: Node, _blackboard: Blackboard) -> void:
 
 # Add custom configuration warnings
 # Note: Can be deleted if you don't want to define your own warnings.
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())

--- a/script_templates/FSMTransition/new_transition.gd
+++ b/script_templates/FSMTransition/new_transition.gd
@@ -1,6 +1,7 @@
 @tool
 extends FSMTransition
 
+
 # Executed when the transition is taken.
 func _on_transition(_delta: float, _actor: Node, _blackboard: Blackboard) -> void:
 	pass
@@ -13,7 +14,7 @@ func is_valid(_actor: Node, _blackboard: Blackboard) -> bool:
 
 # Add custom configuration warnings
 # Note: Can be deleted if you don't want to define your own warnings.
-func _get_configuration_warnings():
+func _get_configuration_warnings() -> PackedStringArray:
 	var warnings: Array = []
 
 	warnings.append_array(super._get_configuration_warnings())


### PR DESCRIPTION
I was getting warnings in the editor with scripts derived from the script templates because they didn't specify a return type for the `_get_configuration_warnings()` function.

That said, this has created four warnings that I cannot understand in VSCode's linting, however that works. So this is theoretically not ready for incorporation without further review.

The errors I'm seeing are all:

    The function signature doesn't match the parent. Parent signature is "_get_configuration_warnings() -> Variant".

This makes no sense to me, because if I ctrl-click to the parent, it clearly shows `-> PackedStringArray`. I'm seeing this for the following files:

* `fsm_state_integrated_bt.gd`
* `fsm_state_integration_return.gd`
* `new_state.gd`
* `new_transition.gd`

The common link here is that these are FSM ones, and the BT ones didn't give me any such issues, but I have no idea if that's relevant.

Also, I have the formatter installed, so various changes to whitespace are a result of that.