### PR TITLE
Add await support to BT

### DIFF
--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random.gd
@@ -20,7 +20,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 	if active_leave == null:
 		active_leave = leaves[rng.randi() % leaves.size()]
 	
-	var response = active_leave.tick(delta, actor, blackboard)
+	var response = await active_leave.tick(delta, actor, blackboard)
 	
 	if response == BTStatus.RUNNING:
 		return response

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_selector.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_selector.gd
@@ -17,7 +17,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		is_shuffled = false
 		return BTStatus.FAILURE
 	
-	var response = leaves[current_leaf].tick(delta, actor, blackboard)
+	var response = await leaves[current_leaf].tick(delta, actor, blackboard)
 
 	if response == BTStatus.SUCCESS:
 		current_leaf = 0

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_sequence.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_random_sequence.gd
@@ -17,7 +17,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		is_shuffled = false
 		return BTStatus.SUCCESS
 
-	var response = leaves[current_leaf].tick(delta, actor, blackboard)
+	var response = await leaves[current_leaf].tick(delta, actor, blackboard)
 
 	if response == BTStatus.RUNNING:
 		return response

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_selector.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_selector.gd
@@ -12,7 +12,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		current_leaf = 0
 		return BTStatus.FAILURE
 	
-	var response = leaves[current_leaf].tick(delta, actor, blackboard)
+	var response = await leaves[current_leaf].tick(delta, actor, blackboard)
 
 	if response == BTStatus.SUCCESS:
 		current_leaf = 0

--- a/addons/behaviour_toolkit/behaviour_tree/composites/bt_sequence.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/composites/bt_sequence.gd
@@ -12,7 +12,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		current_leaf = 0
 		return BTStatus.SUCCESS
 
-	var response = leaves[current_leaf].tick(delta, actor, blackboard)
+	var response = await leaves[current_leaf].tick(delta, actor, blackboard)
 
 	if response == BTStatus.RUNNING:
 		return response

--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_always_fail.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_always_fail.gd
@@ -5,7 +5,7 @@ class_name BTAlwaysFail extends BTDecorator
 
 
 func tick(delta: float, actor: Node, blackboard: Blackboard):
-	var response = leaf.tick(delta, actor, blackboard)
+	var response = await leaf.tick(delta, actor, blackboard)
 
 	if response ==  BTStatus.RUNNING:
 		return BTStatus.RUNNING

--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_always_succeed.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_always_succeed.gd
@@ -5,7 +5,7 @@ class_name BTAlwaysSucceed extends BTDecorator
 
 
 func tick(delta: float, actor: Node, blackboard: Blackboard):
-	var response = leaf.tick(delta, actor, blackboard)
+	var response = await leaf.tick(delta, actor, blackboard)
 
 	if response == BTStatus.RUNNING:
 		return BTStatus.RUNNING

--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_inverter.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_inverter.gd
@@ -5,7 +5,7 @@ class_name BTInverter extends BTDecorator
 
 
 func tick(delta: float, actor: Node, blackboard: Blackboard):
-	var response = leaf.tick(delta, actor, blackboard)
+	var response = await leaf.tick(delta, actor, blackboard)
 
 	if response == BTStatus.SUCCESS:
 		return BTStatus.FAILURE

--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_limiter.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_limiter.gd
@@ -18,7 +18,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		current_count = 0
 	
 	if current_count < limit:
-		var response = leaf.tick(delta, actor, blackboard)
+		var response = await leaf.tick(delta, actor, blackboard)
 		if response == BTStatus.RUNNING:
 			return response
 

--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_repeat.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_repeat.gd
@@ -17,7 +17,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 		current_count = 0
 	
 	if current_count <= repetition:
-		var response = leaf.tick(delta, actor, blackboard)
+		var response = await leaf.tick(delta, actor, blackboard)
 
 		if response == BTStatus.RUNNING:
 			return response

--- a/examples/await_example/await_example.tscn
+++ b/examples/await_example/await_example.tscn
@@ -1,0 +1,22 @@
+[gd_scene load_steps=5 format=3 uid="uid://ceriehd6rqlxg"]
+
+[ext_resource type="Script" path="res://addons/behaviour_toolkit/behaviour_tree/bt_root.gd" id="1_6whv7"]
+[ext_resource type="Script" path="res://addons/behaviour_toolkit/behaviour_tree/composites/bt_sequence.gd" id="2_5i0sw"]
+[ext_resource type="Script" path="res://examples/await_example/contrived_await.gd" id="3_5wavt"]
+[ext_resource type="Script" path="res://addons/behaviour_toolkit/behaviour_tree/leaves/leaf_print.gd" id="4_01exu"]
+
+[node name="AwaitScene" type="Node2D"]
+
+[node name="BTRoot" type="Node" parent="."]
+script = ExtResource("1_6whv7")
+autostart = true
+allow_await = true
+
+[node name="BTSequence" type="Node" parent="BTRoot"]
+script = ExtResource("2_5i0sw")
+
+[node name="ContrivedAwait" type="Node" parent="BTRoot/BTSequence"]
+script = ExtResource("3_5wavt")
+
+[node name="LeafPrint" type="Node" parent="BTRoot/BTSequence"]
+script = ExtResource("4_01exu")

--- a/examples/await_example/contrived_await.gd
+++ b/examples/await_example/contrived_await.gd
@@ -1,0 +1,10 @@
+@tool
+extends BTLeaf
+
+
+# Gets called every tick of the behavior tree
+func tick(_delta: float, _actor: Node, _blackboard: Blackboard) -> BTStatus:
+	# With [BTRoot.allow_await] set to true, this will cause the tree to suspend
+	# execution until this resolves.
+	await get_tree().create_timer(1.0).timeout
+	return BTStatus.SUCCESS


### PR DESCRIPTION
`BTRoot` has been modified with an additional exported variable named `allow_await`. When `true`, the `BTRoot` modifies its flow such that it `await`s for `tick()`, and suspends processing until that `await` returns.

This can be useful when wanting to truly have an actor wait for something to happen without having to fudge around it with nested FSMs or other hacks.

This relates to #78 , and implements it as far as I can tell with a few potential blind spots. Specifically:

- I haven't made any changes to `bt_simple_parallel.gd` because I haven't used those and wasn't sure what appropriate behavior might be when doing an `await` in a parallel context.
- I haven't made any changes to `bt_integrated_fsm.gd`, though that might already just be fine since I modified every place (except the one above) that _calls_ `tick()`.

Very open to feedback, and I know there are multiple PRs pending, but I wanted to put this out there since I had suggested it!

I added a fairly contrived but working example scene that simply waits on a timer to rate-limit a print leaf. That's not how I'd actually use it, but it was a very easy way to see if things were working the way I intended.