### PR TITLE
fix: Correct amount of repetitions, when using the BTRepeat Decorator

### DIFF
--- a/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_repeat.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/decorators/decorator_repeat.gd
@@ -16,7 +16,7 @@ func tick(delta: float, actor: Node, blackboard: Blackboard):
 	if current_count == null:
 		current_count = 0
 	
-	if current_count <= repetition:
+	if current_count < repetition:
 		var response = leaf.tick(delta, actor, blackboard)
 
 		if response == BTStatus.RUNNING:


### PR DESCRIPTION
Perhaps it sounds a bit absurd,but I simply removed a character (changing "<=" to "<") in the BTRepeat script,as having this decorator repeat one more time than the set repetition feels a bit odd :D