### PR TITLE
fix: Dirty Update Manager now doesn't die when unable to fetch the plugin version

### DIFF
--- a/addons/behaviour_toolkit/behaviour_toolkit.gd
+++ b/addons/behaviour_toolkit/behaviour_toolkit.gd
@@ -3,6 +3,13 @@ class_name BehaviourToolkit extends Node
 ## Base class for Behaviour Toolkit plugin nodes.
 
 
+enum LogType {
+    DEFAULT,
+    WARNING,
+    ERROR,
+}
+
+
 class Logger:
     extends BehaviourToolkit
     ## Logger class for Behaviour Toolkit plugin.
@@ -10,12 +17,26 @@ class Logger:
     ## Main color for logger messages.
     const COLOR_MAIN: String = "Orange"
     ## Accent color for logger messages.
-    const COLOR_ACCENT: String = "Yellow"
+    const COLOR_ACCENT: String = "Blue"
+    ## Warning color for logger messages.
+    const COLOR_WARNING: String = "Yellow"
+    ## Error color for logger messages.
+    const COLOR_ERROR: String = "Red"
 
     ## Log a message to the console with the Behaviour Toolkit prefix.
-    static func say(message: String, caller: Node = null) -> void:
+    static func say(message: String, caller: Node = null, type: LogType = LogType.DEFAULT) -> void:
         var log_message: String
         log_message = colorize("[Behaviour Toolkit] ", COLOR_MAIN)
+
+        if not type == LogType.DEFAULT:
+            var color: String
+            match type:
+                LogType.WARNING:
+                    color = COLOR_WARNING
+                LogType.ERROR:
+                    color = COLOR_ERROR
+            
+            log_message += colorize("[" + LogType.keys()[type] + "] ", color)
 
         if caller != null:
 

--- a/addons/behaviour_toolkit/ui/utils/update_manager.gd
+++ b/addons/behaviour_toolkit/ui/utils/update_manager.gd
@@ -16,6 +16,8 @@ signal update_available
 ## The URL to the repository config file. This file has to be the raw version!
 @export var repo_config_url = ""
 
+## Error flag to prevent the error message from printing twice.
+static var had_error: bool = false
 
 ## The current version of the plugin.
 var current_version: String
@@ -68,11 +70,14 @@ func get_newest_version() -> void:
 ## Called when the request to the repository is completed, parses the config file and sets the newest version.
 func _on_http_request_request_completed(result:int, response_code:int, headers:PackedStringArray, body:PackedByteArray):
 	if result != OK:
-		BehaviourToolkit.Logger.say(
-			"Unable to fetch newest version from GitHub. Check your internet connection!",
-			null,
-			BehaviourToolkit.LogType.WARNING
-		)
+		if not had_error:
+			BehaviourToolkit.Logger.say(
+				"Unable to fetch newest version from GitHub. Check your internet connection and reload the editor!",
+				null,
+				BehaviourToolkit.LogType.WARNING
+			)
+			had_error = true
+		
 		emit_signal("update_request_completed")
 		return
 

--- a/addons/behaviour_toolkit/ui/utils/update_manager.gd
+++ b/addons/behaviour_toolkit/ui/utils/update_manager.gd
@@ -66,6 +66,14 @@ func get_newest_version() -> void:
 
 ## Called when the request to the repository is completed, parses the config file and sets the newest version.
 func _on_http_request_request_completed(result:int, response_code:int, headers:PackedStringArray, body:PackedByteArray):
+	if result != OK:
+		BehaviourToolkit.Logger.say(
+			"Unable to fetch newest version from GitHub. Check your internet connection!",
+			null,
+			BehaviourToolkit.LogType.WARNING
+		)
+		return
+
 	var config = ConfigFile.new()
 	var err = config.parse(body.get_string_from_ascii())
 

--- a/addons/behaviour_toolkit/ui/utils/update_manager.gd
+++ b/addons/behaviour_toolkit/ui/utils/update_manager.gd
@@ -24,6 +24,8 @@ var newest_version: String
 
 
 func _ready():
+	current_version = get_current_version()
+
 	# Connect signals
 	connect("request_completed", _on_http_request_request_completed)
 
@@ -36,7 +38,6 @@ func _ready():
 
 func start():
 	# Get versions
-	current_version = get_current_version()
 	get_newest_version()
 
 
@@ -72,6 +73,7 @@ func _on_http_request_request_completed(result:int, response_code:int, headers:P
 			null,
 			BehaviourToolkit.LogType.WARNING
 		)
+		emit_signal("update_request_completed")
 		return
 
 	var config = ConfigFile.new()


### PR DESCRIPTION
This pull request includes several updates to the `BehaviourToolkit` plugin to improve logging functionality and error handling. The most important changes include the addition of a `LogType` enum, enhancements to the `Logger` class, and improvements to the `update_manager.gd` script.


* [`addons/behaviour_toolkit/behaviour_toolkit.gd`](diffhunk://#diff-a514ad6640492db04a81d1f674cf2c32321239485d33c10a503ec814924a7602R6-R40): Added a `LogType` enum to categorize log messages as `DEFAULT`, `WARNING`, or `ERROR`.
* [`addons/behaviour_toolkit/behaviour_toolkit.gd`](diffhunk://#diff-a514ad6640492db04a81d1f674cf2c32321239485d33c10a503ec814924a7602R6-R40): Enhanced the `Logger` class to support different log types with corresponding colors for better message differentiation.
* [`addons/behaviour_toolkit/ui/utils/update_manager.gd`](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661R19-R20): Introduced a `had_error` flag to prevent duplicate error messages when fetching the newest version from GitHub fails. [[1]](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661R19-R20) [[2]](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661R72-R83)
* [`addons/behaviour_toolkit/ui/utils/update_manager.gd`](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661R29-R30): Moved the initialization of `current_version` to the `_ready` function to ensure it is set when the script is ready. [[1]](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661R29-R30) [[2]](diffhunk://#diff-80a4cd08a8b5b5ab15542bca96389d7917fa53e383a24485d57a8643c04fe661L39)