### PR TITLE
Rename BehaviorToolkit.Logger

### DIFF
--- a/addons/behaviour_toolkit/behaviour_toolkit.gd
+++ b/addons/behaviour_toolkit/behaviour_toolkit.gd
@@ -10,7 +10,7 @@ enum LogType {
 }
 
 
-class Logger:
+class BTLogger:
     extends BehaviourToolkit
     ## Logger class for Behaviour Toolkit plugin.
 

--- a/addons/behaviour_toolkit/behaviour_tree/bt_root.gd
+++ b/addons/behaviour_toolkit/behaviour_tree/bt_root.gd
@@ -43,19 +43,19 @@ func _ready() -> void:
 		set_process(false)
 		return
 	
-	if verbose: BehaviourToolkit.Logger.say("Initializing Behavior Tree...", self)
+	if verbose: BehaviourToolkit.BTLogger.say("Initializing Behavior Tree...", self)
 	
 	entry_point = get_child(0)
 	if verbose and entry_point: 
-		BehaviourToolkit.Logger.say("Entry point set to: " + entry_point.name, self)
+		BehaviourToolkit.BTLogger.say("Entry point set to: " + entry_point.name, self)
 	
 	if blackboard == null:
 		blackboard = _create_local_blackboard()
-		if verbose: BehaviourToolkit.Logger.say("Created local blackboard", self)
+		if verbose: BehaviourToolkit.BTLogger.say("Created local blackboard", self)
 
 	if autostart:
 		active = true
-		if verbose: BehaviourToolkit.Logger.say("Autostart enabled", self)
+		if verbose: BehaviourToolkit.BTLogger.say("Autostart enabled", self)
 
 	if not process_type:
 		process_type = ProcessType.PHYSICS
@@ -79,11 +79,11 @@ func _process_code(delta: float) -> void:
 	current_status = entry_point.tick(delta, actor, blackboard)
 	
 	if verbose and previous_status != current_status:
-		BehaviourToolkit.Logger.say("Status changed: " + str(current_status), self)
+		BehaviourToolkit.BTLogger.say("Status changed: " + str(current_status), self)
 
 
 func _create_local_blackboard() -> Blackboard:
-	if verbose: BehaviourToolkit.Logger.say("Creating new blackboard", self)
+	if verbose: BehaviourToolkit.BTLogger.say("Creating new blackboard", self)
 	var blackboard: Blackboard = Blackboard.new()
 	return blackboard
 
@@ -91,7 +91,7 @@ func _create_local_blackboard() -> Blackboard:
 # Configures process type to use, if BTree is not active both are disabled.
 func _setup_processing() -> void:
 	if verbose:
-		BehaviourToolkit.Logger.say("Setting process type: " + str(ProcessType.keys()[process_type]), self)
+		BehaviourToolkit.BTLogger.say("Setting process type: " + str(ProcessType.keys()[process_type]), self)
 	set_physics_process(process_type == ProcessType.PHYSICS)
 	set_process(process_type == ProcessType.IDLE)
 

--- a/addons/behaviour_toolkit/finite_state_machine/fsm.gd
+++ b/addons/behaviour_toolkit/finite_state_machine/fsm.gd
@@ -84,7 +84,7 @@ func _ready() -> void:
 
 
 func start() -> void:
-	if verbose: BehaviourToolkit.Logger.say("Starting FiniteStateMachine...", self)
+	if verbose: BehaviourToolkit.BTLogger.say("Starting FiniteStateMachine...", self)
 
 	current_bt_status = BTBehaviour.BTStatus.RUNNING
 	
@@ -96,7 +96,7 @@ func start() -> void:
 		if state is FSMState:
 			states.append(state)
 
-	if verbose: BehaviourToolkit.Logger.say("Setting up " + str(states.size()) + " states.", self)
+	if verbose: BehaviourToolkit.BTLogger.say("Setting up " + str(states.size()) + " states.", self)
 
 	active = true
 
@@ -160,7 +160,7 @@ func change_state(state: FSMState) -> void:
 	# Enter the new state
 	active_state._on_enter(actor, blackboard)
 
-	if verbose: BehaviourToolkit.Logger.say("Changed state to " + active_state.get_name(), self)
+	if verbose: BehaviourToolkit.BTLogger.say("Changed state to " + active_state.get_name(), self)
 
 	# Emit the state changed signal
 	emit_signal("state_changed", active_state)
@@ -170,7 +170,7 @@ func change_state(state: FSMState) -> void:
 func fire_event(event: String) -> void:
 	current_events.append(event)
 
-	if verbose: BehaviourToolkit.Logger.say("Fired event: " + event, self)
+	if verbose: BehaviourToolkit.BTLogger.say("Fired event: " + event, self)
 
 
 func _create_local_blackboard() -> Blackboard:

--- a/addons/behaviour_toolkit/plugin.gd
+++ b/addons/behaviour_toolkit/plugin.gd
@@ -36,7 +36,7 @@ func _enter_tree():
 	_inspector_plugin = _inspector_plugin.new()
 	add_inspector_plugin(_inspector_plugin)
 
-	BehaviourToolkit.Logger.say("Plugin enabled.")
+	BehaviourToolkit.BTLogger.say("Plugin enabled.")
 
 
 
@@ -49,7 +49,7 @@ func _exit_tree():
 
 	remove_inspector_plugin(_inspector_plugin)
 
-	BehaviourToolkit.Logger.say("Plugin disabled.")
+	BehaviourToolkit.BTLogger.say("Plugin disabled.")
 
 
 func _on_selection_changed() -> void:

--- a/addons/behaviour_toolkit/ui/utils/update_manager.gd
+++ b/addons/behaviour_toolkit/ui/utils/update_manager.gd
@@ -71,7 +71,7 @@ func get_newest_version() -> void:
 func _on_http_request_request_completed(result:int, response_code:int, headers:PackedStringArray, body:PackedByteArray):
 	if result != OK:
 		if not had_error:
-			BehaviourToolkit.Logger.say(
+			BehaviourToolkit.BTLogger.say(
 				"Unable to fetch newest version from GitHub. Check your internet connection and reload the editor!",
 				null,
 				BehaviourToolkit.LogType.WARNING

--- a/project.godot
+++ b/project.godot
@@ -12,7 +12,7 @@ config_version=5
 
 config/name="BehaviourToolkit"
 run/main_scene="res://examples/fsm_character_controller/fsm_character_controller.tscn"
-config/features=PackedStringArray("4.4", "Forward Plus")
+config/features=PackedStringArray("4.5", "Forward Plus")
 config/icon="res://addons/behaviour_toolkit/icons/Logo.png"
 
 [editor_plugins]


### PR DESCRIPTION
Rename Logger to BTLogger to avoid conflict with new built-in class introduced in Godot 4.5.